### PR TITLE
better equality check

### DIFF
--- a/R/personograph.R
+++ b/R/personograph.R
@@ -307,7 +307,7 @@ personograph <- function(data,
                  round.fn=round.standard,
                  colors=as.colors(data)) {
 
-    stopifnot(sum(unlist(data)) == 1)
+    stopifnot(all.equal(sum(unlist(data)), 1))
 
     devAskNewPage(FALSE)
     grid.newpage()

--- a/R/personograph.R
+++ b/R/personograph.R
@@ -225,7 +225,7 @@ round.standard <- function(x) {
 
 round.with.warn <- function(x, f=round.standard, name=NULL) {
     rounded <- f(x)
-    if(x > 0 && rounded == 0) {
+    if(all(x > 0) && all(rounded == 0)) {
         warning(paste("truncating", ifelse(is.null(name), "a", name), "non-zero value of", x, "to 0"))
     }
     rounded


### PR DESCRIPTION
Hi,

Equality checks using "==" can result in failure because of weird floating point behaviour, so all.equal can work better in this instance.

The following would fail if using "==", but not if using all.equal.

personograph::personograph(data = list("Event free" = 0.26067505, "Kidney failure" = 0.6641013, "Death" = 0.07522368))

Thanks!